### PR TITLE
Fix #4 by removing markdown formatting

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -76,7 +76,7 @@ async Task HandleUpdateAsync(ITelegramBotClient botClient, Update update, Cancel
 
         Message newMessage = await botClient.SendTextMessageAsync(
             chatId: chatId,
-            text: "*Welcome to the Password Generator Bot*",
+            text: "Welcome to the Password Generator Bot",
             parseMode: ParseMode.MarkdownV2,
             disableNotification: true,
             replyToMessageId: update.Message.MessageId,


### PR DESCRIPTION
### The asterisks and Markdown formatting were removed from the welcome message text in order to resolve a parsing error.